### PR TITLE
Constant point sources fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: SWATprepR
 Type: Package
 Title: SWAT+ input data preparation tool
 Version: 1.0.12
-Date: 2025-10-12
+Date: 2025-10-22
 Author: c(person("Svajunas", "Plunge",
              email = "svajunas.plunge@gmail.com",
              role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SWATprepR
 Type: Package
 Title: SWAT+ input data preparation tool
-Version: 1.0.13
-Date: 2025-11-11
+Version: 1.0.12
+Date: 2025-10-12
 Author: c(person("Svajunas", "Plunge",
              email = "svajunas.plunge@gmail.com",
              role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SWATprepR
 Type: Package
 Title: SWAT+ input data preparation tool
-Version: 1.0.12
-Date: 2025-10-22
+Version: 1.0.13
+Date: 2025-11-11
 Author: c(person("Svajunas", "Plunge",
              email = "svajunas.plunge@gmail.com",
              role = c("aut", "cre"),

--- a/R/preparing.R
+++ b/R/preparing.R
@@ -1715,8 +1715,11 @@ prepare_ps <- function(pt_lst, project_path, constant = FALSE, write_path = NULL
   id <- 0
   for(i in unique(pt_lst$data$ob_name)){
     ri <- pt_lst$data[pt_lst$data$ob_name == i,]
-    t <- find_time_step(ri[2, "DATE"], ri[1, "DATE"])
-    ri$ob_typ <- paste0(ri$ob_typ, "_", t$typ)
+    # if constant, then time steps do not apply?
+    if(!constant){
+      t <- find_time_step(ri[2, "DATE"], ri[1, "DATE"])
+      ri$ob_typ <- paste0(ri$ob_typ, "_", t$typ)
+    }
     text_l <- paste0(": file was written by SWATprepR R package ", Sys.time())
     if(constant){
       f_rec_path <- paste0(write_path, "/", "exco.exc")


### PR DESCRIPTION
Hi Svajunas,

I was trying to add some constant point sources to a SWAT+ setup, but was getting an error without this adjustment. I can't quite tell what the purpose is of the two lines of code I disabled for `constant = TRUE`, but from what I can tell they shouldnt be necessary for when the point sources have no time scale? 

